### PR TITLE
Broken link to Bootstrap Modal in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ gem install bootstrap-modal-rails
 
 ## Versioning
 
-This gem will directly track the semantic versioning releases of the [https://github.com/jschr/bootstrap-modal](Bootstrap Modal) project.
+This gem will directly track the semantic versioning releases of the [Bootstrap Modal](https://github.com/jschr/bootstrap-modal) project.
 If it should be necessary a build number will be added to the version to mark releases specific to this gem.
 
 ## Note on Patches / Pull Requests


### PR DESCRIPTION
The markdown was backwards (http://daringfireball.net/projects/markdown/syntax#link). I have that link bookmarked because I don't think I've ever remembered the order right on the first try.
